### PR TITLE
Feat/add excel functionality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,9 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     'prettier/prettier': ['error',
       { 'endOfLine': 'auto' }
-    ]
+    ],
   },
+  'no-unused-vars': ['error', {
+    'argsIgnorePattern': '^_',
+  }]
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "exceljs": "^4.4.0",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
+    "multer": "1.4.5-lts.1",
     "nodemailer": "^6.9.15",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      multer:
+        specifier: 1.4.5-lts.1
+        version: 1.4.5-lts.1
       nodemailer:
         specifier: ^6.9.15
         version: 6.9.15
@@ -2388,6 +2391,10 @@ packages:
 
   multer@1.4.4-lts.1:
     resolution: {integrity: sha512-WeSGziVj6+Z2/MwQo3GvqzgR+9Uc+qt8SwHKh3gvNPiISKfsMfG4SvCOFYlxxgkXt7yIV2i1yczehm0EOKIxIg==}
+    engines: {node: '>= 6.0.0'}
+
+  multer@1.4.5-lts.1:
+    resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
     engines: {node: '>= 6.0.0'}
 
   mute-stream@0.0.8:
@@ -6019,6 +6026,16 @@ snapshots:
   ms@2.1.3: {}
 
   multer@1.4.4-lts.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 1.6.2
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
+
+  multer@1.4.5-lts.1:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model User {
   names String
   lastNames String
   email String @unique
-  password String
+  password String?
   role String
   departments String
   directions String

--- a/src/excel/excel.controller.ts
+++ b/src/excel/excel.controller.ts
@@ -2,11 +2,12 @@ import {
   Controller,
   Get,
   Post,
+  Res,
   UploadedFile,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { Express } from 'express';
+import { Express, Response } from 'express';
 
 import { ExcelService } from './excel.service';
 
@@ -20,8 +21,8 @@ export class ExcelController {
   }
 
   @Get('template')
-  async downloadTemplate() {
-    return this.excelService.downloadTemplate();
+  async downloadTemplate(@Res() res: Response) {
+    return this.excelService.downloadTemplate(res);
   }
 
   @Post('update')

--- a/src/excel/excel.controller.ts
+++ b/src/excel/excel.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Query,
   Res,
   UploadedFile,
   UseInterceptors,
@@ -16,8 +17,12 @@ export class ExcelController {
   constructor(private excelService: ExcelService) {}
 
   @Get('download')
-  async downloadFile() {
-    return this.excelService.downloadFile();
+  async downloadFile(
+    @Query('users') users: string,
+    @Query('page') page: number,
+    @Res() res: Response,
+  ) {
+    return this.excelService.downloadFile(users, page, res);
   }
 
   @Get('template')

--- a/src/excel/excel.controller.ts
+++ b/src/excel/excel.controller.ts
@@ -30,9 +30,9 @@ export class ExcelController {
     return this.excelService.downloadTemplate(res);
   }
 
-  @Post('update')
-  @UseInterceptors(FileInterceptor('file'))
-  async updateFile(@UploadedFile() file: Express.Multer.File) {
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('excelFile'))
+  async uploadFile(@UploadedFile() file: Express.Multer.File) {
     return this.excelService.uploadFile(file);
   }
 }

--- a/src/excel/excel.service.ts
+++ b/src/excel/excel.service.ts
@@ -1,4 +1,5 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { Response } from 'express';
 import exceljs from 'exceljs';
 
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -58,7 +59,7 @@ export class ExcelService {
     }
   }
 
-  async downloadTemplate() {
+  async downloadTemplate(res: Response) {
     const book = new exceljs.Workbook();
 
     book.creator = 'Server';
@@ -98,7 +99,10 @@ export class ExcelService {
 
     const buffer = await book.xlsx.writeBuffer();
 
-    return buffer;
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment; filename=template.xlsx');
+
+    return res.end(buffer, 'binary');
   }
 
   async uploadFile(file: Express.Multer.File) {


### PR DESCRIPTION
# Add excel route handlers and services

## Description 🗒️✏️

Added functionality to download an excel file with data from the database, download an excel template, and read data from an excel file and save it into the database.

## How to test it? 🎯⚗️🔬

- Install the dependencies using `pnpm i`.
- For prisma, run `pnpx prisma migrate dev --name init`, then run `pnpx prisma generate`. Aditionally, you can start a local page to inspect the tables using `pnpx prisma studio`, but is not completely necessary.
- Run the frontend app, log in with admin privilegies, and check downloading the excel template, excel file with user data, and uploading an excel file.