### PR TITLE
Feat/add filter order route handlers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,6 @@ module.exports = {
     'prettier/prettier': ['error',
       { 'endOfLine': 'auto' }
     ],
+    'no-unused-vars': ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
   },
-  'no-unused-vars': ['error', {
-    'argsIgnorePattern': '^_',
-  }]
 };

--- a/src/users/dto/order.dto.ts
+++ b/src/users/dto/order.dto.ts
@@ -1,0 +1,24 @@
+import { Transform } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+export class OrderDto {
+  @IsString()
+  column: string;
+
+  @IsString()
+  order: string;
+
+  @IsString()
+  searchValue: string;
+
+  @IsString()
+  searchColumn: string;
+
+  @IsNumber()
+  @Transform(({ value }) => parseInt(value))
+  pageSize: number;
+
+  @IsNumber()
+  @Transform(({ value }) => parseInt(value))
+  page: number;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -13,6 +13,7 @@ import { QueryFilterDto, QueryValuesDto } from './dto/queryValues.dto';
 import { createUserDTO, UpdateUserInfoDTO } from './dto/user.dto';
 import { SafeUser, User } from './entities/user.entity';
 import { UsersService } from './users.service';
+import { OrderDto } from './dto/order.dto';
 
 @Controller('users')
 export class UsersController {
@@ -26,6 +27,11 @@ export class UsersController {
   @Get('filters')
   getFilteredUsers(@Query() queryFilter: QueryFilterDto) {
     return this.userService.getFilteredUsers(queryFilter);
+  }
+
+  @Get('order')
+  getOrderedUsers(@Query() order: OrderDto) {
+    return this.userService.getOrderedUsers(order);
   }
 
   @Get(':id')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -110,6 +110,7 @@ export class UsersService {
       const { column, order, searchValue, searchColumn, pageSize, page } =
         orderFilterData;
 
+      console.log(orderFilterData);
       if (column && order && !searchValue && !searchColumn) {
         return this.prisma.user.findMany({
           orderBy: [
@@ -120,11 +121,44 @@ export class UsersService {
           skip: page === 1 ? 0 : page * pageSize,
           take: pageSize,
         });
-      } else if (!column && !order) {
+      } else if (!column && !order && !searchValue && !searchColumn) {
         return this.prisma.user.findMany({
           skip: page === 1 ? 0 : page * pageSize,
           take: pageSize,
         });
+      } else if (column && order && searchValue && searchColumn) {
+        return this.prisma.user.findMany({
+          orderBy: {
+            [column]: order,
+          },
+          skip: page === 1 ? 0 : page * pageSize,
+          take: pageSize,
+          where: {
+            [searchColumn]: {
+              contains: searchValue,
+            },
+          },
+        });
+      } else if (!column && !order && searchValue && searchColumn) {
+        return this.prisma.user.findMany({
+          skip: page === 1 ? 0 : page * pageSize,
+          take: pageSize,
+          where: {
+            [searchColumn]: {
+              contains: searchValue,
+            },
+          },
+        });
+      } else if (column && !order) {
+        return this.prisma.user.findMany({
+          skip: page === 1 ? 0 : page * pageSize,
+          take: pageSize,
+        });
+      } else {
+        throw new HttpException(
+          'Invalid request, please try again.',
+          HttpStatus.BAD_REQUEST,
+        );
       }
     } catch (error) {
       throw new HttpException(

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,6 +6,7 @@ import { User, Role, SafeUser, ReturnUserData } from './entities/user.entity';
 import { QueryFilterDto, QueryValuesDto } from './dto/queryValues.dto';
 import { createUserDTO, UpdateUserInfoDTO } from './dto/user.dto';
 import { PrismaService } from '../prisma/prisma.service';
+import { OrderDto } from './dto/order.dto';
 
 @Injectable()
 export class UsersService {
@@ -100,6 +101,35 @@ export class UsersService {
         error.response ??
           'There was a problem trying filter users, try again later.',
         error.status ?? HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async getOrderedUsers(orderFilterData: OrderDto) {
+    try {
+      const { column, order, searchValue, searchColumn, pageSize, page } =
+        orderFilterData;
+
+      if (column && order && !searchValue && !searchColumn) {
+        return this.prisma.user.findMany({
+          orderBy: [
+            {
+              [column]: order,
+            },
+          ],
+          skip: page === 1 ? 0 : page * pageSize,
+          take: pageSize,
+        });
+      } else if (!column && !order) {
+        return this.prisma.user.findMany({
+          skip: page === 1 ? 0 : page * pageSize,
+          take: pageSize,
+        });
+      }
+    } catch (error) {
+      throw new HttpException(
+        'There was a problem trying to order and filter the data, try again later.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }


### PR DESCRIPTION
# Add route handlers to filter and order user data

## Description 🗒️✏️

Added functionality to filter the data by typing or by applying an order. Pretty cool imo.

## How to test it? 🎯⚗️🔬

- Install the dependencies using `pnpm i`.
- For prisma, run `pnpx prisma migrate dev --name init`, then run `pnpx prisma generate`. Aditionally, you can start a local page to inspect the tables using `pnpx prisma studio`, but is not completely necessary.
- Run the frontend app, log in with any privileges, and try filtering or searching users.