### PR TITLE
feat: adding authorization to admin routehandlers

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 
 import { UsersController } from './users/users.controller';
 import { PrismaService } from './prisma/prisma.service';
@@ -9,10 +9,29 @@ import { DepartmentsModule } from './departments/departments.module';
 import { ExcelController } from './excel/excel.controller';
 import { ExcelService } from './excel/excel.service';
 import { AuthModule } from './auth/auth.module';
+import { TokenMiddleware } from './token.middleware';
 
 @Module({
   imports: [UsersModule, DirectionsModule, DepartmentsModule, AuthModule],
   controllers: [UsersController, ExcelController],
   providers: [UsersService, PrismaService, ExcelService],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(TokenMiddleware)
+      .forRoutes(
+        { path: 'users', method: RequestMethod.POST },
+        { path: 'users', method: RequestMethod.PATCH },
+        { path: 'users/:id', method: RequestMethod.DELETE },
+        { path: 'users/role/:id', method: RequestMethod.PATCH },
+        { path: 'departments', method: RequestMethod.POST },
+        { path: 'departments/:id', method: RequestMethod.PATCH },
+        { path: 'departments/:id', method: RequestMethod.DELETE },
+        { path: 'directions', method: RequestMethod.POST },
+        { path: 'directions/:id', method: RequestMethod.PATCH },
+        { path: 'directions/:id', method: RequestMethod.DELETE },
+        { path: 'excel', method: RequestMethod.ALL },
+      );
+  }
+}

--- a/src/token.middleware.ts
+++ b/src/token.middleware.ts
@@ -1,0 +1,46 @@
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  NestMiddleware,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { envs } from './config';
+import { UsersService } from './users/users.service';
+
+@Injectable()
+export class TokenMiddleware implements NestMiddleware {
+  constructor(private readonly userService: UsersService) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    const header = req.headers.authorization;
+
+    if (!header || typeof header != 'string') {
+      throw new UnauthorizedException(
+        'Invalid token, log in your account and try again.',
+      );
+    }
+
+    const token = header.slice(7);
+
+    try {
+      const data = jwt.verify(token, envs.secret) as JwtPayload;
+      const userRole = await this.userService.getUser({ rut: data.identifier });
+
+      if (userRole.role === 'USER') {
+        throw new UnauthorizedException(
+          'You dont have the credentials to perform this action, try again.',
+        );
+      }
+      next();
+    } catch (error) {
+      throw new HttpException(
+        error.response ??
+          'There was a problem with the token, try again later.',
+        error.status ?? HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -110,7 +110,6 @@ export class UsersService {
       const { column, order, searchValue, searchColumn, pageSize, page } =
         orderFilterData;
 
-      console.log(orderFilterData);
       if (column && order && !searchValue && !searchColumn) {
         return this.prisma.user.findMany({
           orderBy: [


### PR DESCRIPTION
# Add authorization layer to admin routehandlers

## Description 🗒️✏️

Added an extra authorization layer that acts as a middleware by checking the request header, search for the user in the database, and see if its role is accepted or not.

## How to test it? 🎯⚗️🔬

- Install the dependencies using `pnpm i`.
- For prisma, run `pnpx prisma migrate dev --name init`, then run `pnpx prisma generate`. Aditionally, you can start a local page to inspect the tables using `pnpx prisma studio`, but is not completely necessary.
- Start insomnia or postman and try making a POST request to http://localhost:3000/api/users with some data in its body. If u submit it, it should recieve this:

<div align="center">

![image](https://github.com/user-attachments/assets/ac0d6686-aaba-435f-8e59-2df1191e39c4)

</div>
- You can also try making requests from insmnia WITHOUT the credentials: all of them should return the same error as above.
- Requests you can try:

<div align="center">

![image](https://github.com/user-attachments/assets/3864d5e9-c724-4991-a9fa-c164891c5bb7)


</div>